### PR TITLE
chore: Add missing reference module 2 Java

### DIFF
--- a/functions/java/modules/module2/src/main/java/com/amazonaws/powertools/workshop/Module2Handler.java
+++ b/functions/java/modules/module2/src/main/java/com/amazonaws/powertools/workshop/Module2Handler.java
@@ -2,6 +2,7 @@ package com.amazonaws.powertools.workshop;
 
 import static com.amazonaws.powertools.workshop.Utils.getLabels;
 import static com.amazonaws.powertools.workshop.Utils.reportImageIssue;
+import static java.time.temporal.ChronoUnit.SECONDS;
 
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;


### PR DESCRIPTION
Add missing reference
`import static java.time.temporal.ChronoUnit.SECONDS;`